### PR TITLE
Use Existing Key Pair AWS

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -30,8 +30,6 @@ fileignoreconfig:
   checksum: be22e7624dfa1ad0bbfe57a6205f22cbdafd198b6c4aa2403da0bc7366d4c4cf
 - filename: Azure/Route_Server/admin.auto.tfvars.example
   checksum: 50353e060f88bd8692d5b140ca44100dd6b8c90d0aea67fd38e5c64a89e5ddbe
-- filename: AWS/Autoscale_via_lb/1nic/terraform.tfvars.example
-  checksum: 28ed16029e72f2a7dad510f71bb60cb70d6f0d7468f8c7127546bb8d82c3bfe7
 - filename: AWS/Standalone/terraform.tfvars.example
   checksum: 051def664f2f08f74c399b8ed06a03c4d2d8c83950ebed82bf13c05e89a240ba
 - filename: AWS/Standalone/variables.tf
@@ -74,12 +72,6 @@ fileignoreconfig:
   checksum: 979c385e3173d56e36f02cf05d8e66bfee4f4a20764368fe29ece85ca6cf49cb
 - filename: AWS/Autoscale_via_lb/1nic/variables.tf
   checksum: b66042a0b339fd78deb79125c3ee6303fb0a743c121c3b44fb6c3255a00e1827
-- filename: AWS/Autoscale_via_lb/1nic/f5_onboard.tmpl
-  checksum: ed86217289aa6845640bbcbc94587d3d888fa8a7c603830b1a6b34789ca7598e
-- filename: AWS/Autoscale_via_lb/1nic/bigip.tf
-  checksum: e2c7c4a0403dc529ba8fe55dd9acb0af7ffa58d2c95bc795229d87fbf89f8ada
-- filename: AWS/Autoscale_via_lb/1nic/README.md
-  checksum: 2580803f30ee385df7960cd4bdadf763e20f088c010ca9d66e1f890783529b20
 - filename: Azure/Standalone/terraform.tfvars.example
   checksum: 30c74d5df038e79d8af2e55cc82c1445260a7df53d662c7f8b09b5e93e599900
 - filename: Azure/Standalone/variables.tf
@@ -172,3 +164,11 @@ fileignoreconfig:
   checksum: 764c63eee4f812c34d7df8187bdaaf55c344c5c201cc1baab91b9f90fa05c5bd
 - filename: AWS/HA_via_api/bigip.tf
   checksum: 7481950795c707d4b63ecf9832945525819126811d8fdad87bf72e584a028420
+- filename: AWS/Autoscale_via_lb/1nic/terraform.tfvars.example
+  checksum: bcba5d4c20bb108627c14dc1a278ba4002eb21f34418af2215b0924b0848d340
+- filename: AWS/Autoscale_via_lb/1nic/bigip.tf
+  checksum: ad9c40c31a8ea1eea490b12f6afe99ff586c74a923cb396fbc03adee2016ab1a
+- filename: AWS/Autoscale_via_lb/1nic/README.md
+  checksum: d98712b39cb70a45b460d064e4b601ea28a45569ca6c798b75895c4b0261d6ae
+- filename: AWS/Autoscale_via_lb/1nic/f5_onboard.tmpl
+  checksum: eaa5eae691d0f725f22b149751bf45f611fce6570040048afce4eb76894649bd

--- a/.talismanrc
+++ b/.talismanrc
@@ -33,11 +33,11 @@ fileignoreconfig:
 - filename: AWS/Autoscale_via_lb/1nic/terraform.tfvars.example
   checksum: 28ed16029e72f2a7dad510f71bb60cb70d6f0d7468f8c7127546bb8d82c3bfe7
 - filename: AWS/Standalone/terraform.tfvars.example
-  checksum: 55d1713ecbb90e617b23cc433be5aae7c41f5aa548c33dbb2d8a343e9534a36b
+  checksum: 051def664f2f08f74c399b8ed06a03c4d2d8c83950ebed82bf13c05e89a240ba
 - filename: AWS/Standalone/variables.tf
   checksum: ddfa4b88d8a242ceb3d430ab65502ff1a95e84b1a9ea75ef648a99c578b2a888
 - filename: AWS/Standalone/README.md
-  checksum: dacead7b424d70a49e25c4ef2c54eded826070f0af0ccd983eff947bb1417bfc
+  checksum: ae21b3a3be44da122b40b2b4f340b41499f58e50e05b4023fc91a11780527c89
 - filename: Azure/HA_via_lb/README.md
   checksum: ee5190df812f75cfdb25b6d74e542f8ac3d4e7827830785c3b835b275a10c877
 - filename: GCP/Autoscale_via_lb/1nic/variables.tf
@@ -63,11 +63,11 @@ fileignoreconfig:
 - filename: Azure/Virtual_WAN/README.md
   checksum: d6a729e80ad1ca1346398af7245d7b6a8c4ea1eabe732a0c83c079fd2276f714
 - filename: AWS/Standalone/f5_onboard.tmpl
-  checksum: 34555369c5d833eaeaba856f4e353660ea4219a3b627923aac7da3c73476cd82
+  checksum: 5a19c65113b994b46f3f62bcd24a0c2f0a4e155a8a93d35e27c32f3dba48b2a2
 - filename: AWS/Standalone/iam.tf
   checksum: ceb0254163eb760b9d7b28cf041bf39a34cc6523f245e1459d9f52f74a47cad9
 - filename: AWS/Standalone/bigip.tf
-  checksum: ce85e1256966b66da2a116b9d996874693b815beafd16a38c76d51ba9238dcab
+  checksum: ac53b2b7e7eba0ab41a8265f928df554ede09edc0eaf55dbb19c5b2ccab10e27
 - filename: AWS/HA_via_api/iam.tf
   checksum: ccaf58cadd2be0b108f0fd193ac1a122cbaa0b6d1af01def88c29fd06e191795
 - filename: AWS/HA_via_api/f5_onboard.tmpl

--- a/.talismanrc
+++ b/.talismanrc
@@ -70,14 +70,8 @@ fileignoreconfig:
   checksum: ac53b2b7e7eba0ab41a8265f928df554ede09edc0eaf55dbb19c5b2ccab10e27
 - filename: AWS/HA_via_api/iam.tf
   checksum: ccaf58cadd2be0b108f0fd193ac1a122cbaa0b6d1af01def88c29fd06e191795
-- filename: AWS/HA_via_api/f5_onboard.tmpl
-  checksum: 6ea386ef1c8950e0cae32025b35d31d2ed501213447fb9372bbe9f5ea713a01a
-- filename: AWS/HA_via_api/bigip.tf
-  checksum: 5498a3445b7662fb6bad8935fc0d7afdc63d11630ad86faee390bd41ba2543fe
 - filename: AWS/HA_via_api/variables.tf
   checksum: 979c385e3173d56e36f02cf05d8e66bfee4f4a20764368fe29ece85ca6cf49cb
-- filename: AWS/HA_via_api/README.md
-  checksum: 00d44dadc9d6068feb21c23c009077472de83f9e6a8c64e630f02a3762ad3cc3
 - filename: AWS/Autoscale_via_lb/1nic/variables.tf
   checksum: b66042a0b339fd78deb79125c3ee6303fb0a743c121c3b44fb6c3255a00e1827
 - filename: AWS/Autoscale_via_lb/1nic/f5_onboard.tmpl
@@ -171,4 +165,10 @@ fileignoreconfig:
 - filename: AWS/Infrastructure-only/README.md
   checksum: 0f5cd6bc1471085e76ca168a6578776f4fc185895cc3cbaaf09526915a479d26
 - filename: AWS/HA_via_api/terraform.tfvars.example
-  checksum: 1a18d2c20fccabe21e464db6145d71fc72f8a3500741af4a38e9ed6a07afe6e6
+  checksum: 82bd75c39912ad5de7e1fd902ece5e0f69fc3ee05af6927318f09dc07c249762
+- filename: AWS/HA_via_api/README.md
+  checksum: 5135c3ef33806a82fba90e76d57855e5ff7800d82b397e23ddfcd4ef65f4e076
+- filename: AWS/HA_via_api/f5_onboard.tmpl
+  checksum: 764c63eee4f812c34d7df8187bdaaf55c344c5c201cc1baab91b9f90fa05c5bd
+- filename: AWS/HA_via_api/bigip.tf
+  checksum: 7481950795c707d4b63ecf9832945525819126811d8fdad87bf72e584a028420

--- a/AWS/Autoscale_via_lb/1nic/README.md
+++ b/AWS/Autoscale_via_lb/1nic/README.md
@@ -115,8 +115,8 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.40.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -129,7 +129,6 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 | Name | Type |
 |------|------|
 | [aws_autoscaling_group.bigip-asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
-| [aws_key_pair.bigip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_launch_template.bigip-lt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [random_id.buildSuffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_ami.f5_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
@@ -140,7 +139,6 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | public key used for authentication in ssh-rsa format | `string` | n/a | yes |
 | <a name="input_AS3_URL"></a> [AS3\_URL](#input\_AS3\_URL) | URL to download the BIG-IP Application Service Extension 3 (AS3) module | `string` | `"https://github.com/F5Networks/f5-appsvcs-extension/releases/download/v3.41.0/f5-appsvcs-3.41.0-1.noarch.rpm"` | no |
 | <a name="input_DO_URL"></a> [DO\_URL](#input\_DO\_URL) | URL to download the BIG-IP Declarative Onboarding module | `string` | `"https://github.com/F5Networks/f5-declarative-onboarding/releases/download/v1.34.0/f5-declarative-onboarding-1.34.0-5.noarch.rpm"` | no |
 | <a name="input_FAST_URL"></a> [FAST\_URL](#input\_FAST\_URL) | URL to download the BIG-IP FAST module | `string` | `"https://github.com/F5Networks/f5-appsvcs-templates/releases/download/v1.22.0/f5-appsvcs-templates-1.22.0-1.noarch.rpm"` | no |
@@ -167,6 +165,7 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 | <a name="input_bigIqUsername"></a> [bigIqUsername](#input\_bigIqUsername) | Admin name for BIG-IQ | `string` | `"azureuser"` | no |
 | <a name="input_dns_server"></a> [dns\_server](#input\_dns\_server) | Leave the default DNS server the BIG-IP uses, or replace the default DNS server with the one you want to use | `string` | `"8.8.8.8"` | no |
 | <a name="input_ec2_instance_type"></a> [ec2\_instance\_type](#input\_ec2\_instance\_type) | AWS instance type for the BIG-IP | `string` | `"m5n.xlarge"` | no |
+| <a name="input_ec2_key_name"></a> [ec2\_key\_name](#input\_ec2\_key\_name) | AWS EC2 Key name for SSH access | `string` | `null` | no |
 | <a name="input_extNsg"></a> [extNsg](#input\_extNsg) | ID of external security group | `string` | `null` | no |
 | <a name="input_extSubnetAz1"></a> [extSubnetAz1](#input\_extSubnetAz1) | ID of External subnet AZ1 | `string` | `null` | no |
 | <a name="input_extSubnetAz2"></a> [extSubnetAz2](#input\_extSubnetAz2) | ID of External subnet AZ2 | `string` | `null` | no |
@@ -202,7 +201,7 @@ To run this Terraform template, perform the following steps:
       extSubnetAz1 = "subnet-1234"
       extSubnetAz2 = "subnet-5678"
       extNsg       = "sg-0123"
-      ssh_key      = "ssh-rsa AAABC123....."
+      ec2_key_name = "mySshKey123"
       f5_username  = "admin"
       f5_password  = "Default12345!"
 

--- a/AWS/Autoscale_via_lb/1nic/bigip.tf
+++ b/AWS/Autoscale_via_lb/1nic/bigip.tf
@@ -25,14 +25,6 @@ data "aws_ami" "f5_ami" {
   }
 }
 
-############################ SSH Key pair ############################
-
-# Create SSH Key Pair
-resource "aws_key_pair" "bigip" {
-  key_name   = format("%s-key-%s", var.projectPrefix, random_id.buildSuffix.hex)
-  public_key = var.ssh_key
-}
-
 ############################ Onboard Scripts ############################
 
 # Setup Onboarding scripts
@@ -42,7 +34,6 @@ locals {
     f5_password                 = var.aws_secretmanager_auth ? "" : var.f5_password
     aws_secretmanager_auth      = var.aws_secretmanager_auth
     aws_secretmanager_secret_id = var.aws_secretmanager_auth ? data.aws_secretsmanager_secret_version.current[0].secret_id : ""
-    ssh_keypair                 = var.ssh_key
     INIT_URL                    = var.INIT_URL
     DO_URL                      = var.DO_URL
     AS3_URL                     = var.AS3_URL
@@ -71,7 +62,7 @@ resource "aws_launch_template" "bigip-lt" {
   name          = format("%s-bigip-lt-%s", var.projectPrefix, random_id.buildSuffix.hex)
   image_id      = data.aws_ami.f5_ami.id
   instance_type = var.ec2_instance_type
-  key_name      = aws_key_pair.bigip.key_name
+  key_name      = var.ec2_key_name
   user_data     = base64encode(local.f5_onboard)
 
   network_interfaces {

--- a/AWS/Autoscale_via_lb/1nic/f5_onboard.tmpl
+++ b/AWS/Autoscale_via_lb/1nic/f5_onboard.tmpl
@@ -12,6 +12,13 @@ exec 1>&-
 exec 1>$npipe
 exec 2>&1
 
+# Run Immediately Before MCPD starts
+/usr/bin/setdb provision.extramb 1000
+/usr/bin/setdb restjavad.useextramb true
+
+# save config
+tmsh save sys config
+ssh_keypair2=$(cat /home/admin/.ssh/authorized_keys)
 
 ### write_files:
 # Download or Render BIG-IP Runtime Init Config
@@ -24,8 +31,8 @@ runtime_parameters:
     value: ${f5_username}
   - name: SSH_KEYS
     type: static
-    value: ${ssh_keypair}
 EOF
+echo "    value: $ssh_keypair2" >> /config/cloud/runtime-init-conf.yaml
 
 if ${aws_secretmanager_auth}; then
    cat << 'EOF' >> /config/cloud/runtime-init-conf.yaml
@@ -147,7 +154,7 @@ EOF
 
 # Download BIG-IP Runtime Init
 for i in {1..30}; do
-    curl -fv --retry 1 --connect-timeout 5 -L ${INIT_URL} -o "/var/config/rest/downloads/f5-bigip-runtime.gz.run" && break || sleep 10
+    curl -fv --retry 1 --connect-timeout 5 -L ${INIT_URL} -o "/var/config/rest/downloads/f5-bigip-runtime-init.gz.run" && break || sleep 10
 done
 
 # Remove comment to do silly debugging on BIG-IP Runtime init
@@ -155,7 +162,7 @@ done
 # export F5_BIGIP_RUNTIME_EXTENSION_INSTALL_DELAY_IN_MS=60000
 
 # Install BIG-IP Runtime Init
-bash /var/config/rest/downloads/f5-bigip-runtime.gz.run -- '--cloud aws'
+bash /var/config/rest/downloads/f5-bigip-runtime-init.gz.run -- '--cloud aws'
 
 # Run BIG-IP Runtime Init and Process YAML
 f5-bigip-runtime-init --config-file /config/cloud/runtime-init-conf.yaml

--- a/AWS/Autoscale_via_lb/1nic/terraform.tfvars.example
+++ b/AWS/Autoscale_via_lb/1nic/terraform.tfvars.example
@@ -4,7 +4,7 @@ vpcId        = "vpc-1234"
 extSubnetAz1 = "subnet-1234"
 extSubnetAz2 = "subnet-5678"
 extNsg       = "sg-0123"
-ssh_key      = "ssh-rsa AAABC123....."
+ec2_key_name = "mySshKey123"
 f5_username  = "admin"
 f5_password  = "Default12345!"
 

--- a/AWS/Autoscale_via_lb/1nic/variables.tf
+++ b/AWS/Autoscale_via_lb/1nic/variables.tf
@@ -70,6 +70,11 @@ variable "ec2_instance_type" {
   description = "AWS instance type for the BIG-IP"
   default     = "m5n.xlarge"
 }
+variable "ec2_key_name" {
+  type        = string
+  description = "AWS EC2 Key name for SSH access"
+  default     = null
+}
 variable "f5_username" {
   type        = string
   description = "User name for the BIG-IP (Note: currenlty not used. Defaults to 'admin' based on AMI"
@@ -94,10 +99,6 @@ variable "aws_iam_instance_profile" {
   description = "Name of IAM role to assign to the BIG-IP instance"
   type        = string
   default     = null
-}
-variable "ssh_key" {
-  type        = string
-  description = "public key used for authentication in ssh-rsa format"
 }
 variable "dns_server" {
   type        = string

--- a/AWS/HA_via_api/README.md
+++ b/AWS/HA_via_api/README.md
@@ -135,7 +135,7 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.40.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.45.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
@@ -161,7 +161,6 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 | [aws_ec2_tag.bigip_int_nicmap](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
 | [aws_iam_instance_profile.bigip_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.bigip_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_key_pair.bigip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_route_table.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_s3_bucket.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
@@ -179,7 +178,6 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | public key used for authentication in ssh-rsa format | `string` | n/a | yes |
 | <a name="input_AS3_URL"></a> [AS3\_URL](#input\_AS3\_URL) | URL to download the BIG-IP Application Service Extension 3 (AS3) module | `string` | `"https://github.com/F5Networks/f5-appsvcs-extension/releases/download/v3.41.0/f5-appsvcs-3.41.0-1.noarch.rpm"` | no |
 | <a name="input_CFE_URL"></a> [CFE\_URL](#input\_CFE\_URL) | URL to download the BIG-IP Cloud Failover Extension module | `string` | `"https://github.com/F5Networks/f5-cloud-failover-extension/releases/download/v1.13.0/f5-cloud-failover-1.13.0-0.noarch.rpm"` | no |
 | <a name="input_DO_URL"></a> [DO\_URL](#input\_DO\_URL) | URL to download the BIG-IP Declarative Onboarding module | `string` | `"https://github.com/F5Networks/f5-declarative-onboarding/releases/download/v1.34.0/f5-declarative-onboarding-1.34.0-5.noarch.rpm"` | no |
@@ -205,6 +203,7 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 | <a name="input_cfe_managed_route"></a> [cfe\_managed\_route](#input\_cfe\_managed\_route) | A route can used for testing managed-route failover. Enter address prefix like x.x.x.x/x | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_dns_server"></a> [dns\_server](#input\_dns\_server) | Leave the default DNS server the BIG-IP uses, or replace the default DNS server with the one you want to use | `string` | `"8.8.8.8"` | no |
 | <a name="input_ec2_instance_type"></a> [ec2\_instance\_type](#input\_ec2\_instance\_type) | AWS instance type for the BIG-IP | `string` | `"m5n.xlarge"` | no |
+| <a name="input_ec2_key_name"></a> [ec2\_key\_name](#input\_ec2\_key\_name) | AWS EC2 Key name for SSH access | `string` | `null` | no |
 | <a name="input_extNsg"></a> [extNsg](#input\_extNsg) | ID of external security group | `string` | `null` | no |
 | <a name="input_extSubnetAz1"></a> [extSubnetAz1](#input\_extSubnetAz1) | ID of External subnet AZ1 | `string` | `null` | no |
 | <a name="input_extSubnetAz2"></a> [extSubnetAz2](#input\_extSubnetAz2) | ID of External subnet AZ2 | `string` | `null` | no |
@@ -272,7 +271,7 @@ To run this Terraform template, perform the following steps:
       mgmtNsg       = "sg-1111"
       extNsg        = "sg-3333"
       intNsg        = "sg-5555"
-      ssh_key       = "ssh-rsa AAABC123....."
+      ec2_key_name  = "mySshKey123"
       f5_username   = "admin"
       f5_password   = "Default12345!"
 

--- a/AWS/HA_via_api/bigip.tf
+++ b/AWS/HA_via_api/bigip.tf
@@ -62,14 +62,6 @@ data "aws_ami" "f5_ami" {
   }
 }
 
-############################ SSH Key pair ############################
-
-# Create SSH Key Pair
-resource "aws_key_pair" "bigip" {
-  key_name   = format("%s-key-%s", var.projectPrefix, random_id.buildSuffix.hex)
-  public_key = var.ssh_key
-}
-
 ############################ Onboard Scripts ############################
 
 # Setup Onboarding scripts
@@ -80,7 +72,6 @@ locals {
     f5_password                 = var.aws_secretmanager_auth ? "" : var.f5_password
     aws_secretmanager_auth      = var.aws_secretmanager_auth
     aws_secretmanager_secret_id = var.aws_secretmanager_auth ? data.aws_secretsmanager_secret_version.current[0].secret_id : ""
-    ssh_keypair                 = var.ssh_key
     INIT_URL                    = var.INIT_URL
     DO_URL                      = var.DO_URL
     AS3_URL                     = var.AS3_URL
@@ -120,7 +111,6 @@ locals {
     f5_password                 = var.aws_secretmanager_auth ? "" : var.f5_password
     aws_secretmanager_auth      = var.aws_secretmanager_auth
     aws_secretmanager_secret_id = var.aws_secretmanager_auth ? data.aws_secretsmanager_secret_version.current[0].secret_id : ""
-    ssh_keypair                 = var.ssh_key
     INIT_URL                    = var.INIT_URL
     DO_URL                      = var.DO_URL
     AS3_URL                     = var.AS3_URL
@@ -164,7 +154,7 @@ module "bigip" {
   version                    = "1.1.8"
   prefix                     = format("%s-3nic", var.projectPrefix)
   ec2_instance_type          = var.ec2_instance_type
-  ec2_key_name               = aws_key_pair.bigip.key_name
+  ec2_key_name               = var.ec2_key_name
   f5_ami_search_name         = var.f5_ami_search_name
   f5_username                = var.f5_username
   aws_iam_instance_profile   = var.aws_iam_instance_profile == null ? aws_iam_instance_profile.bigip_profile[0].name : var.aws_iam_instance_profile
@@ -184,7 +174,7 @@ module "bigip2" {
   version                    = "1.1.8"
   prefix                     = format("%s-3nic", var.projectPrefix)
   ec2_instance_type          = var.ec2_instance_type
-  ec2_key_name               = aws_key_pair.bigip.key_name
+  ec2_key_name               = var.ec2_key_name
   f5_ami_search_name         = var.f5_ami_search_name
   f5_username                = var.f5_username
   aws_iam_instance_profile   = var.aws_iam_instance_profile == null ? aws_iam_instance_profile.bigip_profile[0].name : var.aws_iam_instance_profile

--- a/AWS/HA_via_api/f5_onboard.tmpl
+++ b/AWS/HA_via_api/f5_onboard.tmpl
@@ -12,6 +12,13 @@ exec 1>&-
 exec 1>$npipe
 exec 2>&1
 
+# Run Immediately Before MCPD starts
+/usr/bin/setdb provision.extramb 1000
+/usr/bin/setdb restjavad.useextramb true
+
+# save config
+tmsh save sys config
+ssh_keypair2=$(cat /home/admin/.ssh/authorized_keys)
 
 ### write_files:
 # Download or Render BIG-IP Runtime Init Config
@@ -24,8 +31,8 @@ runtime_parameters:
     value: ${f5_username}
   - name: SSH_KEYS
     type: static
-    value: ${ssh_keypair}
 EOF
+echo "    value: $ssh_keypair2" >> /config/cloud/runtime-init-conf.yaml
 
 if ${aws_secretmanager_auth}; then
    cat << 'EOF' >> /config/cloud/runtime-init-conf.yaml
@@ -354,7 +361,7 @@ EOF
 
 # Download BIG-IP Runtime Init
 for i in {1..30}; do
-    curl -fv --retry 1 --connect-timeout 5 -L ${INIT_URL} -o "/var/config/rest/downloads/f5-bigip-runtime.gz.run" && break || sleep 10
+    curl -fv --retry 1 --connect-timeout 5 -L ${INIT_URL} -o "/var/config/rest/downloads/f5-bigip-runtime-init.gz.run" && break || sleep 10
 done
 
 # Remove comment to do silly debugging on BIG-IP Runtime init
@@ -362,7 +369,7 @@ done
 # export F5_BIGIP_RUNTIME_EXTENSION_INSTALL_DELAY_IN_MS=60000
 
 # Install BIG-IP Runtime Init
-bash /var/config/rest/downloads/f5-bigip-runtime.gz.run -- '--cloud aws'
+bash /var/config/rest/downloads/f5-bigip-runtime-init.gz.run -- '--cloud aws'
 
 # Run BIG-IP Runtime Init and Process YAML
 f5-bigip-runtime-init --config-file /config/cloud/runtime-init-conf.yaml

--- a/AWS/HA_via_api/terraform.tfvars.example
+++ b/AWS/HA_via_api/terraform.tfvars.example
@@ -10,7 +10,7 @@ intSubnetAz2  = "subnet-6666"
 mgmtNsg       = "sg-1111"
 extNsg        = "sg-3333"
 intNsg        = "sg-5555"
-ssh_key       = "ssh-rsa AAABC123....."
+ec2_key_name  = "mySshKey123"
 f5_username   = "admin"
 f5_password   = "Default12345!"
 

--- a/AWS/HA_via_api/variables.tf
+++ b/AWS/HA_via_api/variables.tf
@@ -90,6 +90,11 @@ variable "ec2_instance_type" {
   description = "AWS instance type for the BIG-IP"
   default     = "m5n.xlarge"
 }
+variable "ec2_key_name" {
+  type        = string
+  description = "AWS EC2 Key name for SSH access"
+  default     = null
+}
 variable "f5_username" {
   type        = string
   description = "User name for the BIG-IP (Note: currenlty not used. Defaults to 'admin' based on AMI"
@@ -114,10 +119,6 @@ variable "aws_iam_instance_profile" {
   description = "Name of IAM role to assign to the BIG-IP instance"
   type        = string
   default     = null
-}
-variable "ssh_key" {
-  type        = string
-  description = "public key used for authentication in ssh-rsa format"
 }
 variable "license1" {
   type        = string

--- a/AWS/Standalone/README.md
+++ b/AWS/Standalone/README.md
@@ -130,8 +130,8 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.45.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 
@@ -145,7 +145,6 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 |------|------|
 | [aws_iam_instance_profile.bigip_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.bigip_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_key_pair.bigip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [random_id.buildSuffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_ami.f5_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_policy_document.bigip_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -158,7 +157,6 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | public key used for authentication in ssh-rsa format | `string` | n/a | yes |
 | <a name="input_AS3_URL"></a> [AS3\_URL](#input\_AS3\_URL) | URL to download the BIG-IP Application Service Extension 3 (AS3) module | `string` | `"https://github.com/F5Networks/f5-appsvcs-extension/releases/download/v3.41.0/f5-appsvcs-3.41.0-1.noarch.rpm"` | no |
 | <a name="input_DO_URL"></a> [DO\_URL](#input\_DO\_URL) | URL to download the BIG-IP Declarative Onboarding module | `string` | `"https://github.com/F5Networks/f5-declarative-onboarding/releases/download/v1.34.0/f5-declarative-onboarding-1.34.0-5.noarch.rpm"` | no |
 | <a name="input_FAST_URL"></a> [FAST\_URL](#input\_FAST\_URL) | URL to download the BIG-IP FAST module | `string` | `"https://github.com/F5Networks/f5-appsvcs-templates/releases/download/v1.22.0/f5-appsvcs-templates-1.22.0-1.noarch.rpm"` | no |
@@ -181,6 +179,7 @@ This template uses PayGo BIG-IP image for the deployment (as default). If you wo
 | <a name="input_bigIqUsername"></a> [bigIqUsername](#input\_bigIqUsername) | Admin name for BIG-IQ | `string` | `"azureuser"` | no |
 | <a name="input_dns_server"></a> [dns\_server](#input\_dns\_server) | Leave the default DNS server the BIG-IP uses, or replace the default DNS server with the one you want to use | `string` | `"8.8.8.8"` | no |
 | <a name="input_ec2_instance_type"></a> [ec2\_instance\_type](#input\_ec2\_instance\_type) | AWS instance type for the BIG-IP | `string` | `"m5n.xlarge"` | no |
+| <a name="input_ec2_key_name"></a> [ec2\_key\_name](#input\_ec2\_key\_name) | AWS EC2 Key name for SSH access | `string` | `null` | no |
 | <a name="input_extNsg"></a> [extNsg](#input\_extNsg) | ID of external security group | `string` | `null` | no |
 | <a name="input_extSubnetAz1"></a> [extSubnetAz1](#input\_extSubnetAz1) | ID of External subnet AZ1 | `string` | `null` | no |
 | <a name="input_f5_ami_search_name"></a> [f5\_ami\_search\_name](#input\_f5\_ami\_search\_name) | AWS AMI search filter to find correct BIG-IP VE for region | `string` | `"F5 BIGIP-16.1.3.2* PAYG-Best Plus 200Mbps*"` | no |
@@ -230,7 +229,7 @@ To run this Terraform template, perform the following steps:
       mgmtNsg       = "sg-1111"
       extNsg        = "sg-3333"
       intNsg        = "sg-5555"
-      ssh_key       = "ssh-rsa AAABC123....."
+      ec2_key_name  = "mySshKey123"
       f5_username   = "admin"
       f5_password   = "Default12345!"
 

--- a/AWS/Standalone/bigip.tf
+++ b/AWS/Standalone/bigip.tf
@@ -49,14 +49,6 @@ data "aws_ami" "f5_ami" {
   }
 }
 
-############################ SSH Key pair ############################
-
-# Create SSH Key Pair
-resource "aws_key_pair" "bigip" {
-  key_name   = format("%s-key-%s", var.projectPrefix, random_id.buildSuffix.hex)
-  public_key = var.ssh_key
-}
-
 ############################ Onboard Scripts ############################
 
 # Setup Onboarding scripts
@@ -67,7 +59,6 @@ locals {
     f5_password                 = var.aws_secretmanager_auth ? "" : var.f5_password
     aws_secretmanager_auth      = var.aws_secretmanager_auth
     aws_secretmanager_secret_id = var.aws_secretmanager_auth ? data.aws_secretsmanager_secret_version.current[0].secret_id : ""
-    ssh_keypair                 = var.ssh_key
     INIT_URL                    = var.INIT_URL
     DO_URL                      = var.DO_URL
     AS3_URL                     = var.AS3_URL
@@ -101,7 +92,7 @@ module "bigip" {
   version                    = "1.1.8"
   prefix                     = format("%s-3nic", var.projectPrefix)
   ec2_instance_type          = var.ec2_instance_type
-  ec2_key_name               = aws_key_pair.bigip.key_name
+  ec2_key_name               = var.ec2_key_name
   f5_ami_search_name         = var.f5_ami_search_name
   f5_username                = var.f5_username
   aws_iam_instance_profile   = var.aws_iam_instance_profile == null ? aws_iam_instance_profile.bigip_profile[0].name : var.aws_iam_instance_profile

--- a/AWS/Standalone/f5_onboard.tmpl
+++ b/AWS/Standalone/f5_onboard.tmpl
@@ -12,6 +12,13 @@ exec 1>&-
 exec 1>$npipe
 exec 2>&1
 
+# Run Immediately Before MCPD starts
+/usr/bin/setdb provision.extramb 1000
+/usr/bin/setdb restjavad.useextramb true
+
+# save config
+tmsh save sys config
+ssh_keypair2=$(cat /home/admin/.ssh/authorized_keys)
 
 ### write_files:
 # Download or Render BIG-IP Runtime Init Config
@@ -24,8 +31,8 @@ runtime_parameters:
     value: ${f5_username}
   - name: SSH_KEYS
     type: static
-    value: ${ssh_keypair}
 EOF
+echo "    value: $ssh_keypair2" >> /config/cloud/runtime-init-conf.yaml
 
 if ${aws_secretmanager_auth}; then
    cat << 'EOF' >> /config/cloud/runtime-init-conf.yaml
@@ -243,7 +250,7 @@ EOF
 
 # Download BIG-IP Runtime Init
 for i in {1..30}; do
-    curl -fv --retry 1 --connect-timeout 5 -L ${INIT_URL} -o "/var/config/rest/downloads/f5-bigip-runtime.gz.run" && break || sleep 10
+    curl -fv --retry 1 --connect-timeout 5 -L ${INIT_URL} -o "/var/config/rest/downloads/f5-bigip-runtime-init.gz.run" && break || sleep 10
 done
 
 # Remove comment to do silly debugging on BIG-IP Runtime init
@@ -251,7 +258,7 @@ done
 # export F5_BIGIP_RUNTIME_EXTENSION_INSTALL_DELAY_IN_MS=60000
 
 # Install BIG-IP Runtime Init
-bash /var/config/rest/downloads/f5-bigip-runtime.gz.run -- '--cloud aws'
+bash /var/config/rest/downloads/f5-bigip-runtime-init.gz.run -- '--cloud aws'
 
 # Run BIG-IP Runtime Init and Process YAML
 f5-bigip-runtime-init --config-file /config/cloud/runtime-init-conf.yaml

--- a/AWS/Standalone/terraform.tfvars.example
+++ b/AWS/Standalone/terraform.tfvars.example
@@ -7,7 +7,7 @@ intSubnetAz1  = "subnet-5555"
 mgmtNsg       = "sg-1111"
 extNsg        = "sg-3333"
 intNsg        = "sg-5555"
-ssh_key       = "ssh-rsa AAABC123....."
+ec2_key_name  = "mySshKey123"
 f5_username   = "admin"
 f5_password   = "Default12345!"
 

--- a/AWS/Standalone/variables.tf
+++ b/AWS/Standalone/variables.tf
@@ -65,6 +65,11 @@ variable "ec2_instance_type" {
   description = "AWS instance type for the BIG-IP"
   default     = "m5n.xlarge"
 }
+variable "ec2_key_name" {
+  type        = string
+  description = "AWS EC2 Key name for SSH access"
+  default     = null
+}
 variable "f5_username" {
   type        = string
   description = "User name for the BIG-IP (Note: currenlty not used. Defaults to 'admin' based on AMI"
@@ -89,10 +94,6 @@ variable "aws_iam_instance_profile" {
   description = "Name of IAM role to assign to the BIG-IP instance"
   type        = string
   default     = null
-}
-variable "ssh_key" {
-  type        = string
-  description = "public key used for authentication in ssh-rsa format"
 }
 variable "license1" {
   type        = string


### PR DESCRIPTION
- update code to require and use existing key pair
- f5_onboard updates for ssh auth keys
- bigip.tf update for ec2_key_name